### PR TITLE
Don't include the <bit> when C++20 is not available

### DIFF
--- a/include/memPool.h
+++ b/include/memPool.h
@@ -29,7 +29,9 @@
 #define MEMPOOL_H
 
 #include <vector>
+#if __cplusplus >= 202002L
 #include <bit>
+#endif
 #include <bitset>
 #include <cstdint>
 


### PR DESCRIPTION
Although the usage of std::countl_zero has been moved into a #ifdef/#endif, the `include` doesn't. This change fix the problem.