### PR TITLE
Add a virtual destructor to genericPoint

### DIFF
--- a/include/implicit_point.h
+++ b/include/implicit_point.h
@@ -65,6 +65,7 @@ protected:
 
 public:
 	genericPoint(const Point_Type& t) : type(t) {}
+	virtual ~genericPoint() = default;
 
 	Point_Type getType() const { return type; }
 	bool is2D() const { return type <= SSI; }


### PR DESCRIPTION
As a class that mean to be inherited, a virtual destrustor is necessary for polymorphism.